### PR TITLE
ci: Add CI via github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+---
+# GitHub Actions CI workflow for jsonnext
+
+name: ci
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.14'
+      - run: make test
+      - run: make cover
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.27
+  bump_version:
+    name: bump version
+    runs-on: ubuntu-latest
+    needs: [ test, lint ]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.17.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-coverage.out
+/out/


### PR DESCRIPTION
Add a GitHub Actions workflow to perform CI that runs the tests, checks
coverage, lints the code and if merging to master, bumps the version and
pushes a new tag.

Update the `Makefile` to the latest foxygoat standard and push it further
including:
* Rework lint so there are permanent `lint-local` and `lint-with-docker`
rules, and select from them with a dynamic target from `lint`.
* Rename `check-coverage` to `cover` and `cover` to `showcover` -
this seems to more clearly reflect what they do and the prefix for
`showcover` is unique enough that `make sh<TAB>` completes well.
* Put output files in the `out/` directory. Make clean just removes that.
The coverage file is now `out/coverage.txt` as it is a text file.
* Remove the build section for now as there is nothing to build. It will
come back shortly, shorter and sweeter.