### PR TITLE
build: Fix make all to run cover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 O = out
 
-all: test check-coverage lint  ## test, check coverage and lint
+all: test cover lint  ## test, check coverage and lint
 	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 


### PR DESCRIPTION
The old target name for checking coverage (`check-coverage`) was used
instead of the new `cover` target as a prerequisite of the `all` target.

Fixes: 90fa1b2d04449f201994a8559c440a063df557de