### PR TITLE
Housekeeping: Clean up CI & Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,18 +28,3 @@ jobs:
       - uses: golangci/golangci-lint-action@v1
         with:
           version: v1.27
-  bump_version:
-    name: bump version
-    runs-on: ubuntu-latest
-    needs: [ test, lint ]
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.17.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,23 @@
+---
+# GitHub Actions version bump workflow for jsonnext
+
+name: bump version
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  bump_version:
+    name: bump version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.17.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-#
-# Generic Makefile for Go programs
-#
-
+# --- Global -------------------------------------------------------------------
 O = out
 
 all: test cover lint  ## test, check coverage and lint
@@ -9,16 +6,15 @@ all: test cover lint  ## test, check coverage and lint
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 
 clean::  ## Remove generated files
-	-rm -rf $O
+	-rm -rf $(O)
 
 .PHONY: all clean
 
 # --- Test ---------------------------------------------------------------------
-
-COVERFILE = $O/coverage.txt
+COVERFILE = $(O)/coverage.txt
 COVERAGE = 96.5
 
-test: | $O ## Run tests and generate a coverage file
+test: | $(O)  ## Run tests and generate a coverage file
 	go test -coverprofile=$(COVERFILE) ./...
 
 cover: test  ## Check that test coverage meets the required level
@@ -33,16 +29,15 @@ FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_
 .PHONY: test cover showcover
 
 # --- Lint ---------------------------------------------------------------------
-
 GOLINT_VERSION = 1.27.0
 GOLINT_INSTALLED_VERSION = $(or $(word 4,$(shell golangci-lint --version 2>/dev/null)),0.0.0)
 GOLINT_MIN_VERSION = $(shell printf '%s\n' $(GOLINT_VERSION) $(GOLINT_INSTALLED_VERSION) | sort -V | head -n 1)
 GOPATH1 = $(firstword $(subst :, ,$(GOPATH)))
-LINT_TARGET = lint-$(if $(filter $(GOLINT_MIN_VERSION),$(GOLINT_VERSION)),local,with-docker)
+LINT_TARGET = $(if $(filter $(GOLINT_MIN_VERSION),$(GOLINT_VERSION)),lint-with-local,lint-with-docker)
 
 lint: $(LINT_TARGET)  ## Lint source code
 
-lint-local:  ## Lint source code with locally installed golangci-lint
+lint-with-local:  ## Lint source code with locally installed golangci-lint
 	golangci-lint run
 
 lint-with-docker:  ## Lint source code with docker image of golangci-lint
@@ -53,7 +48,6 @@ lint-with-docker:  ## Lint source code with docker image of golangci-lint
 .PHONY: lint lint-local lint-with-docker
 
 # --- Utilities ----------------------------------------------------------------
-
 COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
 COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)
 COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ lint-with-local:  ## Lint source code with locally installed golangci-lint
 	golangci-lint run
 
 lint-with-docker:  ## Lint source code with docker image of golangci-lint
-	docker run --rm -v $(GOPATH1):/go -v $(PWD):/src -w /src \
+	docker run --rm -w /src \
+		-v $(PWD):/src -v $(GOPATH1):/go -v $(HOME)/.cache:/root/.cache \
 		golangci/golangci-lint:v$(GOLINT_VERSION) \
 		golangci-lint run
 


### PR DESCRIPTION
Split the version bump into a separate workflow run only on master,
instead of running on PRs too but being skipped.

Clean up the Makefile standardising the expansion of `$(O)`, fixing the
name of `lint-with-local` and persisting the cache when running lint in
docker.