### PR TITLE
doc: Fix package-level docs to show properly

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -10,5 +10,4 @@
 // This form of netpath makes it simpler to use in a PATH-style,
 // colon-separated environment variable where the colon in a URL would need to
 // be escaped.
-
 package jsonnext


### PR DESCRIPTION
An extra blank line ended up in the go docs from commit 6c9d2d69 when
the package level docs were moved to `doc.go`. The extra newline between
the package doc and the `package` statement means that comment is not
interpreted as package-level docs.

Remove that blank line.