### PR TITLE
lib: Add a jsonnet utilities library

### DIFF
--- a/lib/array.jsonnet
+++ b/lib/array.jsonnet
@@ -1,0 +1,34 @@
+// Package array contains utility functions for working with arrays.
+{
+  local array = self,
+  local op = import 'op.jsonnet',
+  local value = import 'value.jsonnet',
+
+  // make returns its argument if it is an array, otherwise returns a single
+  // element array containing the argument.
+  make(any):: if std.isArray(any) then any else [any],
+
+  // coalesce returns the first non-null value from the given array or null
+  // if there are none.
+  coalesce(arr)::
+    if arr == [] then null
+    else if arr[0] != null then arr[0]
+    else array.coalesce(arr[1:]),
+
+  // collapse returns the input array with any null values removed
+  collapse(arr):: [e for e in arr if e != null],
+
+  // accumulate adds all the elements in the array @arr together starting
+  // with the value @init. If @init is not supplied or null, the zero value
+  // of the first element of the array is used. If the array is empty, @init
+  // is returned.
+  //
+  // The values in the array can be any types that can be added together with
+  // the plus (+) operator. Numbers are summed, strings and arrays are
+  // concatenated and objects are merged. Booleans and functions do not
+  // support the plus operator. Strings can be added to any type resulting
+  // in the other type being converted to a string before concatenating.
+  accumulate(arr, init=null)::
+    local zero = if std.length(arr) > 0 then value.zero(arr[0]) else null;
+    std.foldl(op.add, arr, array.coalesce([init, zero])),
+}

--- a/lib/array_test.jsonnet
+++ b/lib/array_test.jsonnet
@@ -1,0 +1,71 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+
+local array = import 'array.jsonnet';
+local test = import 'jsonnetunit/test.libsonnet';
+
+{ name: 'array.jsonnet test' } +
+test.suite({
+  // tests for array.make(any)
+  testMakeNonArray: {
+    actual: array.make(42),
+    expect: [42],
+  },
+  testMakeArray: {
+    actual: array.make([42]),
+    expect: [42],
+  },
+
+  // tests for array.coalesce(arr)
+  testCoalesceFirst: {
+    actual: array.coalesce([1, null, 2]),
+    expect: 1,
+  },
+  testCoalesceSecond: {
+    actual: array.coalesce([null, 1, 2]),
+    expect: 1,
+  },
+  testCoalesceEmpty: {
+    actual: array.coalesce([]),
+    expect: null,
+  },
+  testCoalesceNull: {
+    actual: array.coalesce([null]),
+    expect: null,
+  },
+
+  // tests for array.colapse(arr)
+  testCollapseNulls: {
+    actual: array.collapse([null, null]),
+    expect: [],
+  },
+  testCollapseEmpty: {
+    actual: array.collapse([]),
+    expect: [],
+  },
+  testCollapseFull: {
+    actual: array.collapse([1, 2, 3, 4]),
+    expect: [1, 2, 3, 4],
+  },
+  testCollapsePartial: {
+    actual: array.collapse([1, null, 2, null, null, 3, 4]),
+    expect: [1, 2, 3, 4],
+  },
+
+  // tests for array.accumulate(arr, init)
+  testAccumulate: {
+    actual: array.accumulate([1, 1, 2, 3, 5, 8, 13]),
+    expect: 33,
+  },
+  testAccumulateInit: {
+    actual: array.accumulate([1, 1, 2, 3, 5, 8, 13], 21),
+    expect: 54,
+  },
+  testAccumulateEmpty: {
+    actual: array.accumulate([]),
+    expect: null,
+  },
+  testAccumulateEmptyInit: {
+    actual: array.accumulate([], 42),
+    expect: 42,
+  },
+})

--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -1,6 +1,7 @@
 // Package jx is a top-level package to import the subpackages of the
 // jx library.
 {
+  array:: import 'array.jsonnet',
   op:: import 'op.jsonnet',
   string:: import 'string.jsonnet',
   value:: import 'value.libsonnet',

--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -2,6 +2,7 @@
 // jx library.
 {
   array:: import 'array.jsonnet',
+  object:: import 'object.jsonnet',
   op:: import 'op.jsonnet',
   string:: import 'string.jsonnet',
   value:: import 'value.libsonnet',

--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -1,0 +1,5 @@
+// Package jx is a top-level package to import the subpackages of the
+// jx library.
+{
+  value:: import 'value.libsonnet',
+}

--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -1,5 +1,6 @@
 // Package jx is a top-level package to import the subpackages of the
 // jx library.
 {
+  string:: import 'string.jsonnet',
   value:: import 'value.libsonnet',
 }

--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -1,6 +1,7 @@
 // Package jx is a top-level package to import the subpackages of the
 // jx library.
 {
+  op:: import 'op.jsonnet',
   string:: import 'string.jsonnet',
   value:: import 'value.libsonnet',
 }

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -5,6 +5,7 @@
 
 [
   import 'array_test.jsonnet',
+  import 'object_test.jsonnet',
   import 'op_test.jsonnet',
   import 'string_test.jsonnet',
   import 'value_test.jsonnet',

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -4,6 +4,7 @@
 //
 
 [
+  import 'op_test.jsonnet',
   import 'string_test.jsonnet',
   import 'value_test.jsonnet',
 ]

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -4,6 +4,7 @@
 //
 
 [
+  import 'array_test.jsonnet',
   import 'op_test.jsonnet',
   import 'string_test.jsonnet',
   import 'value_test.jsonnet',

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+//
+// Roll-up all the tests in this directory
+//
+
+[
+  import 'value_test.jsonnet',
+]

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -4,5 +4,6 @@
 //
 
 [
+  import 'string_test.jsonnet',
   import 'value_test.jsonnet',
 ]

--- a/lib/object.jsonnet
+++ b/lib/object.jsonnet
@@ -1,0 +1,97 @@
+// Package object contains utility functions for working with objects.
+{
+  local object = self,
+  local array = import 'array.jsonnet',
+
+  // make returns an object from an array @arr of `[key, value]` pairs. The
+  // fields in the returned object are all visible (non-hidden).
+  make(arr):: { [kv[0]]: kv[1] for kv in arr },
+
+  // makeHidden returns an object from an array @arr of `[key, value]` pairs.
+  // The fields in the returned object are all hidden.
+  makeHidden(arr):: array.accumulate([{ [kv[0]]:: kv[1] } for kv in arr], {}),
+
+  // keys returns all the non-hidden field keys of @obj in an array. It is
+  // identical to std.objectFields and exists here to fill out the 3x3 matrix
+  // of functions for (keys, vals, kv) x (visble, all, hidden).
+  keys(obj):: std.objectFields(obj),
+
+  // keysAll returns all the field keys (hidden and non-hidden) of @obj in an
+  // array. It is identical to std.objectFieldsAll and exists here to fill out
+  // the 3x3 matrix of functions for (keys, vals, kv) x (visble, all, hidden).
+  keysAll(obj):: std.objectFieldsAll(obj),
+
+  // keysHidden returns all the hidden field keys of @obj in an array.
+  keysHidden(obj):: std.setDiff(object.keysAll(obj), object.keys(obj)),
+
+  // vals returns all the non-hidden field values of @obj in an array.
+  vals(obj):: [obj[k] for k in object.keys(obj)],
+
+  // valsAll returns all the field values (hidden and non-hidden) of @obj in an
+  // array.
+  valsAll(obj):: [obj[k] for k in object.keysAll(obj)],
+
+  // valsHidden returns all the hidden field values of @obj in an array.
+  valsHidden(obj):: [obj[k] for k in object.keysHidden(obj)],
+
+  // kv returns all the non-hidden fields of @obj as an array of `[key, value]`
+  // pairs.
+  kv(obj):: [[k, obj[k]] for k in object.keys(obj)],
+
+  // kvAll returns all the fields (hidden and non-hidden) of @obj as an array
+  // of `[key, value]` pairs.
+  kvAll(obj):: [[k, obj[k]] for k in object.keysAll(obj)],
+
+  // kvHidden returns all the hidden fields of @obj as an array of
+  // `[key, value]` pairs.
+  kvHidden(obj):: [[k, obj[k]] for k in object.keysHidden(obj)],
+
+  // transform calls @fn(key, value) on each field of @obj passing it the key
+  // and the value of each field and using the result of @fn to build the
+  // result of transform. It can remove fields, rename fields or change the
+  // value of fields based on what the given function @fn returns.
+  //
+  // The signature of @fn is fn(key, value) => [newkey, newval] | null.
+  // If @fn returns null, the field is removed from the result of transform.
+  // Otherwise @fn should return a `[newkey, newvalue]` pair which is put into
+  // the result of transform as a field. The visibility of the field in the
+  // result object is the same as the visibility of the field passed to @fn.
+  transform(fn, obj)::
+    local kvToArgs(fn) = function(kv) fn(kv[0], kv[1]);
+    local visible = array.collapse(std.map(kvToArgs(fn), object.kv(obj)));
+    local hidden = array.collapse(std.map(kvToArgs(fn), object.kvHidden(obj)));
+    object.make(visible) + object.makeHidden(hidden),
+
+  // filter calls @fn on each field of @obj passing it the key and the value
+  // of each field and returns an object with the fields for which @fn
+  // returned true.
+  filter(fn, obj)::
+    local map_fn(k, v) = if fn(k, v) then [k, v] else null;
+    object.transform(map_fn, obj),
+
+  // removeField returns @obj with @field removed from it.
+  removeField(obj, field):: object.removeFields(obj, [field]),
+
+  // removeFields returns @obj with each field listed in @fields removed
+  // from it.
+  removeFields(obj, fields)::
+    local remove = std.set(fields);
+    local keep_fn(k, v) = !std.setMember(k, remove);
+    object.filter(keep_fn, obj),
+
+  // invert swaps keys and values in @obj. The values in the output object is a
+  // list of keys of visible (non-hidden) fields from @obj. If any of the
+  // values in @obj cannot be keys in an object (i.e. non-string values),
+  // jsonnet will produce an evaluation error.
+  // `{ a: 'foo', b: 'bar', c:: 'foo' }` -> `{ bar: ['b'], foo: ['a'] }`
+  invert(obj):: __invert(obj, object.keys),
+
+  // invertAll swaps keys and values in @obj. The values in the output object
+  // is a list of all keys (visible and hidden) of fields from @obj. If any of
+  // the values in @obj cannot be keys in an object (i.e. non-string values),
+  // jsonnet will produce an evaluation error.
+  // `{ a: 'foo', b: 'bar', c:: 'bar' }` -> `{ bar: ['b', 'c'], foo: ['a'] }`
+  invertAll(obj):: __invert(obj, object.keysAll),
+
+  local __invert(obj, selector) = array.accumulate([{ [obj[k]]+: [k] } for k in selector(obj)]),
+}

--- a/lib/object_test.jsonnet
+++ b/lib/object_test.jsonnet
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+
+local test = import 'jsonnetunit/test.libsonnet';
+local object = import 'object.jsonnet';
+
+{ name: 'object.jsonnet test' } +
+test.suite({
+  local o = { a: 1, b: 2, c:: 3, d:: 4 },
+
+  testKeys: {
+    actual: object.keys(o),
+    expect: ['a', 'b'],
+  },
+  testKeysEmpty: {
+    actual: object.keys({}),
+    expect: [],
+  },
+
+  testKeysAll: {
+    actual: object.keysAll(o),
+    expect: ['a', 'b', 'c', 'd'],
+  },
+  testKeysAllEmpty: {
+    actual: object.keysAll({}),
+    expect: [],
+  },
+
+  testKeysHidden: {
+    actual: object.keysHidden(o),
+    expect: ['c', 'd'],
+  },
+  testKeysHiddenEmpty: {
+    actual: object.keysHidden({}),
+    expect: [],
+  },
+
+  testVals: {
+    actual: object.vals(o),
+    expect: [1, 2],
+  },
+  testValsEmpty: {
+    actual: object.vals({}),
+    expect: [],
+  },
+
+  testValsAll: {
+    actual: object.valsAll(o),
+    expect: [1, 2, 3, 4],
+  },
+  testValsAllEmpty: {
+    actual: object.valsAll({}),
+    expect: [],
+  },
+
+  testValsHidden: {
+    actual: object.valsHidden(o),
+    expect: [3, 4],
+  },
+  testValsHiddenEmpty: {
+    actual: object.valsHidden({}),
+    expect: [],
+  },
+
+  testKV: {
+    actual: object.kv(o),
+    expect: [['a', 1], ['b', 2]],
+  },
+  testKVEmpty: {
+    actual: object.kv({}),
+    expect: [],
+  },
+
+  testKVAll: {
+    actual: object.kvAll(o),
+    expect: [['a', 1], ['b', 2], ['c', 3], ['d', 4]],
+  },
+  testKVAllEmpty: {
+    actual: object.kvAll({}),
+    expect: [],
+  },
+
+  testKVHidden: {
+    actual: object.kvHidden(o),
+    expect: [['c', 3], ['d', 4]],
+  },
+  testKVHiddenEmpty: {
+    actual: object.kvHidden({}),
+    expect: [],
+  },
+
+  testMake: {
+    actual: object.make([['a', 1], ['b', 2]]),
+    expect: o,  // only the visible fields are compared.
+  },
+  testMakeEmpty: {
+    actual: object.make([]),
+    expect: {},
+  },
+
+  testMakeHidden: {
+    // Hidden object fields are not compared when testing for equality,
+    // so we just make sure we get our input back out using object.kvAll.
+    local input = [['c', 3], ['d', 4]],
+    actual: object.kvAll(object.makeHidden(input)),
+    expect: input,
+  },
+  testMakeHiddenEmpty: {
+    // Hidden object fields are not compared when testing for equality,
+    // so we just make sure we get our input back out using object.kvAll.
+    actual: object.kvAll(object.makeHidden([])),
+    expect: [],
+  },
+
+  testTransformKey: {
+    // we need to use object.kvAll to compare the hidden fields
+    actual: object.make(object.kvAll(object.transform(function(k, v) [k + 'x', v], o))),
+    expect: { ax: 1, bx: 2, cx: 3, dx: 4 },
+  },
+  testTransformKeyVisible: {
+    actual: object.transform(function(k, v) [k + 'x', v], o),
+    expect: { ax: 1, bx: 2 },
+  },
+  testTransformKeyHidden: {
+    // we need to use object.kvHidden to compare the hidden fields
+    actual: object.make(object.kvHidden(object.transform(function(k, v) [k + 'x', v], o))),
+    expect: { cx: 3, dx: 4 },
+  },
+  testTransformValue: {
+    actual: object.transform(function(k, v) [k, v + 1], o),
+    expect: { a: 2, b: 3 },  // only visible fields are compared
+  },
+  testTransformRemove: {
+    actual: object.transform(function(k, v) null, o),
+    expect: {},
+  },
+
+  testFilterKeep: {
+    actual: object.kvAll(object.filter(function(k, v) true, o)),
+    expect: [['a', 1], ['b', 2], ['c', 3], ['d', 4]],
+  },
+  testFilterRemove: {
+    actual: object.kvAll(object.filter(function(k, v) false, o)),
+    expect: [],
+  },
+
+  testRemoveField: {
+    actual: object.kvAll(object.removeField(o, 'a')),
+    expect: [['b', 2], ['c', 3], ['d', 4]],
+  },
+  testRemoveFields: {
+    actual: object.kvAll(object.removeFields(o, ['a', 'c'])),
+    expect: [['b', 2], ['d', 4]],
+  },
+
+  testInvert: {
+    actual: object.invert({ a: 'foo', b: 'bar', c:: 'bar', d:: 'baz' }),
+    expect: { foo: ['a'], bar: ['b'] },
+  },
+  testInvertAll: {
+    actual: object.invertAll({ a: 'foo', b: 'bar', c:: 'bar', d:: 'baz' }),
+    expect: { foo: ['a'], bar: ['b', 'c'], baz: ['d'] },
+  },
+})

--- a/lib/op.jsonnet
+++ b/lib/op.jsonnet
@@ -1,0 +1,33 @@
+// Package op provides function values for the built-in functions.
+// These can be useful with functions such as std.foldl where you
+// want to fold with a built-in function.
+{
+  local op = self,
+
+  add(a, b):: a + b,
+  sub(a, b):: a - b,
+  mul(a, b):: a * b,
+  div(a, b):: a / b,
+  mod(a, b):: a % b,
+  neg(a):: -a,
+
+  eq(a, b):: a == b,
+  ne(a, b):: a != b,
+  lt(a, b):: a < b,
+  le(a, b):: a <= b,
+  gt(a, b):: a > b,
+  ge(a, b):: a >= b,
+
+  lsh(a, b):: a << b,
+  rsh(a, b):: a >> b,
+  band(a, b):: a & b,
+  bor(a, b):: a | b,
+  bxor(a, b):: a ^ b,
+  bcpl(a):: ~a,
+
+  and(a, b):: a && b,
+  or(a, b):: a || b,
+  not(a):: !a,
+
+  inobj(a, b):: a in b,
+}

--- a/lib/op_test.jsonnet
+++ b/lib/op_test.jsonnet
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+
+local test = import 'jsonnetunit/test.libsonnet';
+local op = import 'op.jsonnet';
+
+{ name: 'op.jsonnet test' } +
+test.suite({
+  testAdd: { actual: op.add(20, 22), expect: 42 },
+  testSub: { actual: op.sub(66, 24), expect: 42 },
+  testMul: { actual: op.mul(6, 7), expect: 42 },
+  testDiv: { actual: op.div(252, 6), expect: 42 },
+  testMod: { actual: op.mod(109, 67), expect: 42 },
+  testNeg: { actual: op.neg(-42), expect: 42 },
+
+  testEq1: { actual: op.eq(42, 42), expect: true },
+  testEq2: { actual: op.eq(42, 41), expect: false },
+  testNe1: { actual: op.ne(42, 42), expect: false },
+  testNe2: { actual: op.ne(42, 41), expect: true },
+  testLt1: { actual: op.lt(41, 42), expect: true },
+  testLt2: { actual: op.lt(42, 42), expect: false },
+  testLe1: { actual: op.le(41, 42), expect: true },
+  testLe2: { actual: op.le(42, 42), expect: true },
+  testLe3: { actual: op.le(43, 42), expect: false },
+  testGt1: { actual: op.gt(42, 41), expect: true },
+  testGt2: { actual: op.gt(42, 42), expect: false },
+  testGe1: { actual: op.ge(42, 41), expect: true },
+  testGe2: { actual: op.ge(42, 42), expect: true },
+  testGe3: { actual: op.ge(42, 43), expect: false },
+
+  testLsh: { actual: op.lsh(21, 1), expect: 42 },
+  testRsh: { actual: op.rsh(168, 2), expect: 42 },
+  testBand: { actual: op.band(171, 110), expect: 42 },
+  testBor: { actual: op.bor(40, 10), expect: 42 },
+  testBxor: { actual: op.bxor(78, 100), expect: 42 },
+  testBcpl: { actual: op.bcpl(-43), expect: 42 },
+
+  testAnd1: { actual: op.and(true, true), expect: true },
+  testAnd2: { actual: op.and(true, false), expect: false },
+  testAnd3: { actual: op.and(false, true), expect: false },
+  testAnd4: { actual: op.and(false, false), expect: false },
+  testOr1: { actual: op.and(true, true), expect: true },
+  testOr2: { actual: op.or(true, false), expect: true },
+  testOr3: { actual: op.or(false, true), expect: true },
+  testOr4: { actual: op.or(false, false), expect: false },
+  testNot1: { actual: op.not(true), expect: false },
+  testNot2: { actual: op.not(false), expect: true },
+
+  testInObj1: { actual: op.inobj('a', { a: 42 }), expect: true },
+  testInObj2: { actual: op.inobj('b', { a: 42 }), expect: false },
+})

--- a/lib/string.jsonnet
+++ b/lib/string.jsonnet
@@ -1,0 +1,19 @@
+// Package string provides utility functions for working with strings.
+{
+  local string = self,
+
+  // contains returns true if @substr is in @str, false if it is not. @str and
+  // @substr must be a string. If @substr is empty then true is returned.
+  //
+  // Note: The implementation uses `std.strReplace` as this is built-in in the
+  // Go implementation and is likely the fastest way.
+  contains(str, substr)::
+    if !std.isString(str) then
+      error ('string.contains first param must be a string, got ' + std.type(str))
+    else if !std.isString(substr) then
+      error ('string.contains second param must be a string, got ' + std.type(substr))
+    else if std.length(substr) == 0 then
+      true
+    else
+      std.strReplace(str, substr, '') != str,
+}

--- a/lib/string_test.jsonnet
+++ b/lib/string_test.jsonnet
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+
+local test = import 'jsonnetunit/test.libsonnet';
+local string = import 'string.jsonnet';
+
+{ name: 'string.jsonnet test' } +
+test.suite({
+  testStrContains: {
+    actual: string.contains('hello', 'el'),
+    expect: true,
+  },
+
+  testStrDoesntContain: {
+    actual: string.contains('hello', 'xx'),
+    expect: false,
+  },
+
+  testEmptyStrDoesntContain: {
+    actual: string.contains('', 'x'),
+    expect: false,
+  },
+
+  testStrContainsEmpty: {
+    actual: string.contains('hello', ''),
+    expect: true,
+  },
+
+  testEmptyContainsEmpty: {
+    actual: string.contains('', ''),
+    expect: true,
+  },
+})

--- a/lib/value.jsonnet
+++ b/lib/value.jsonnet
@@ -1,0 +1,37 @@
+// Package value contains utility functions for working with arbitrary values.
+{
+  local value = self,
+
+  // get indexes the data structure @any successively with the elements of
+  // @path and returns the value accessed. If indexing by any element of the
+  // path results in an unknown or invalid field/index, the @default value is
+  // returned.
+  // @path can be either an array of indicies or a single value of an index.
+  get(any, path, default=null)::
+    if path == [] then any
+    else if !std.isArray(path) then value.get(any, [path], default)
+    else
+      local idx = path[0];
+      local validIdxType =
+        (std.isArray(any) && std.isNumber(idx)) ||
+        (std.isObject(any) && std.isString(idx));
+      local knownIdx =
+        (std.isArray(any) && idx >= 0 && idx < std.length(any)) ||
+        (std.isObject(any) && idx in any);
+      if validIdxType && knownIdx then value.get(any[idx], path[1:], default)
+      else default,
+
+  // zero returns a zero value for the type of the given argument. The zero
+  // value for a function is a nullary function that returns null.
+  zero(any)::
+    if std.isBoolean(any) then false
+    else if std.isNumber(any) then 0
+    else if std.isString(any) then ''
+    else if std.isArray(any) then []
+    else if std.isObject(any) then {}
+    else if std.isFunction(any) then function() null
+    else null,
+
+  // identity returns its argument. If no argument is provided, null is returned.
+  identity(any=null):: any,
+}

--- a/lib/value_test.jsonnet
+++ b/lib/value_test.jsonnet
@@ -1,0 +1,79 @@
+#!/usr/bin/env -S jx -J //github.com/yugui/jsonnetunit/raw/master
+
+local test = import 'jsonnetunit/test.libsonnet';
+local value = import 'value.jsonnet';
+
+{ name: 'value.jsonnet test' } +
+test.suite({
+  local getFixture = { a: 1, b: null, c: [1, 2, 3], d: { x: 'x', y: { z: 'z' } } },
+  testGetNoPath: {
+    actual: value.get(getFixture, []),
+    expect: getFixture,
+  },
+  testGetStringPath: {
+    actual: value.get(getFixture, 'a'),
+    expect: 1,
+  },
+  testGetPathOneLevel: {
+    actual: value.get(getFixture, ['a']),
+    expect: 1,
+  },
+  testGetArray: {
+    actual: value.get(getFixture.c, 2),
+    expect: 3,
+  },
+  testGetObjDefault: {
+    actual: value.get(getFixture, 'non-existent', 'default'),
+    expect: 'default',
+  },
+  testGetArrayDefault: {
+    actual: value.get(getFixture.c, 3, 42),
+    expect: 42,
+  },
+  testGetDefaultNull: {
+    actual: value.get(getFixture, 'non-existent'),
+    expect: null,
+  },
+  testGetPath: {
+    actual: value.get(getFixture, ['d', 'y', 'z']),
+    expect: 'z',
+  },
+  testGetNull: {
+    actual: value.get(getFixture, 'b', 'not-null'),
+    expect: null,
+  },
+
+  testZeroBool: {
+    actual: value.zero(true),
+    expect: false,
+  },
+  testZeroNumber: {
+    actual: value.zero(42),
+    expect: 0,
+  },
+  testZeroString: {
+    actual: value.zero('hello world'),
+    expect: '',
+  },
+  testZeroArray: {
+    actual: value.zero([1, 2, 3, 4]),
+    expect: [],
+  },
+  testZeroObject: {
+    actual: value.zero({ a: 1, b:: 2, c::: 3 }),
+    expect: {},
+  },
+  testZeroFunction: {
+    actual: value.zero(value.zero),
+    expectThat: function(actual) actual() == null,
+  },
+
+  testID: {
+    actual: value.identity(42),
+    expect: 42,
+  },
+  testIDNull: {
+    actual: value.identity(),
+    expect: null,
+  },
+})


### PR DESCRIPTION
Add a library of jsonnet code for general purpose manipulation of
jsonnet values.

Currently it has five components: array, object, string and value
which provide functions that operate on arrays, object strings and any
values; and op which provides functions for built-in operators.

A top-level import, `jx` imports them all into a common object.

Tests are provided for all functions, and the test runner has been added
to the `make test` target. It imports jsonnetunit
(github.com/yugui/jsonnetunit) by relative import, with the test files
running with a shebang using the `jx` binary in this repo and setting a
network import path to import the jsonnet unit library. `jx` needs to be
in your path to run the tests directly, but the `make test-jsonnet`
target depends on `jx` and builds it to use.