### PR TITLE
lib: Fix filename import in top-level jx.jsonnet

### DIFF
--- a/lib/jx.jsonnet
+++ b/lib/jx.jsonnet
@@ -5,5 +5,5 @@
   object:: import 'object.jsonnet',
   op:: import 'op.jsonnet',
   string:: import 'string.jsonnet',
-  value:: import 'value.libsonnet',
+  value:: import 'value.jsonnet',
 }

--- a/lib/jx_test.jsonnet
+++ b/lib/jx_test.jsonnet
@@ -3,7 +3,20 @@
 // Roll-up all the tests in this directory
 //
 
+local test = import 'jsonnetunit/test.libsonnet';
+local jx = import 'jx.jsonnet';
+
+local jx_test = { name: 'jx.jsonnet test' } + test.suite({
+  testImport: {
+    // Force evaluation of imports in `jx.jsonnet` by using std.prune over
+    // all fields. This will cause a failure if a file cannot be imported.
+    actual: std.prune(std.objectValuesAll(jx)),
+    expect: [],  // empty because all fields are hidden and thus pruned.
+  },
+});
+
 [
+  jx_test,
   import 'array_test.jsonnet',
   import 'object_test.jsonnet',
   import 'op_test.jsonnet',


### PR DESCRIPTION
The top-level `jx.jsonnet` was importing `value.jsonnet` as
`value.libsonnet` as I made a recent decision to stop using the
`.libsonnet` extension, but I forgot to update that one reference.

Add a test to `jx_test.jsonnet` to test that all the imports work, and
that everything imported is hidden.