### PR TITLE
ci: Bump version of golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v1
+      - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.31


### PR DESCRIPTION
Bump the version of the golangci-lint-action version from v1 to v2. Not
sure why we were using v1, but there are currently strange errors in CI
where lint runs successfully, but the action step fails. See if using
the latest version works.