### PR TITLE
importer: Handle "", "-" and "/dev/stdin" as stdin

### DIFF
--- a/cmd/jx/main.go
+++ b/cmd/jx/main.go
@@ -26,10 +26,6 @@ func main() {
 }
 
 func run(vm *jsonnet.VM, filename string) (string, error) {
-	if filename == "" || filename == "-" {
-		filename = "/dev/stdin"
-	}
-
 	node, _, err := vm.ImportAST("", filename)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Add special case handing of import files named `""` (empty string),
`"-"` and `"/dev/stdin"` as stdin. These are all stored in the cache
keyed by the empty string, so any imports read from stdin will be
searched relative to the current directory. Previously, to read stdin
required using the filename `/dev/stdin`, which meant any imports in the
stdin stream were searched relative to `/dev`.

Remove the special handling of stdin from the `jx` command now that the
importer does it.

Tested with:

    $ echo 42 > out/foo.jsonnet
    $ ./out/jx
    import 'out/foo.jsonnet'
    42

Fixes: https://github.com/foxygoat/jsonnext/issues/26