### PR TITLE
flag: Add --max-{stack,trace} flags

### DIFF
--- a/cmd/jx/doc.go
+++ b/cmd/jx/doc.go
@@ -1,19 +1,21 @@
 // jx evaluates a jsonnet file and outputs it as JSON.
 //
-//   Usage: jx [<filename>]
+// Usage: jx [<filename>]
 //
-//   Arguments:
-//     [<filename>]    File to evaluate. stdin is used if omitted or "-"
+// Arguments:
+//   [<filename>]    File to evaluate. stdin is used if omitted or "-"
 //
-//   Flags:
-//     -h, --help                      Show context-sensitive help.
-//     -J, --jpath=dir                 Add a library search dir
-//     -V, --ext-str=var[=str]         Add extVar string (from environment if <str> is omitted)
-//         --ext-code=var[=code]       Add extVar code (from environment if <code> is omitted)
-//         --ext-str-file=var=file     Add extVar string from a file
-//         --ext-code-file=var=file    Add extVar code from a file
-//     -A, --tla-str=var[=str]         Add top-level arg string (from environment if <str> is omitted)
-//         --tla-code=var[=code]       Add top-level arg code (from environment if <code> is omitted)
-//         --tla-str-file=var=file     Add top-level arg string from a file
-//         --tla-code-file=var=file    Add top-level arg code from a file
+// Flags:
+//   -h, --help                            Show context-sensitive help.
+//   -J, --jpath=dir                       Add a library search dir
+//       --max-stack=500                   Number of allowed stack frames of jsonnet VM
+//       --max-trace=20                    Maximum number of stack frames output on error
+//   -V, --ext-str=var[=str]               Set extVar string (str from env if omitted)
+//       --ext-str-file=var[=filename]     Set extVar string from a file (filename from env if omitted)
+//       --ext-code=var[=code]             Set extVar code (code from env if omitted)
+//       --ext-code-file=var[=filename]    Set extVar code from a file (filename from env if omitted)
+//   -A, --tla-str=var[=str]               Set top-level arg string (str from env if omitted)
+//       --tla-str-file=var[=filename]     Set top-level arg string from a file (filename from env if omitted)
+//       --tla-code=var[=code]             Set top-level arg code (code from env if omitted)
+//       --tla-code-file=var[=filename]    Set top-level arg code from a file (filename from env if omitted)
 package main

--- a/conformance/clitest.go
+++ b/conformance/clitest.go
@@ -141,3 +141,31 @@ func (s *Suite) TestImportPath() {
 	expected.ImportPath = []string{"a", "b"}
 	require.Equal(t, expected, cfg)
 }
+
+// TestMaxStack tests that the MaxStack field is set by the --max-stack flag,
+// and that the default is set when the flag is not present.
+func (s *Suite) TestMaxStack() {
+	t := s.T()
+
+	cfg, err := s.parser.Parse(t, []string{t.Name(), "--max-stack", "10"})
+	require.NoError(t, err)
+	require.Equal(t, 10, cfg.MaxStack)
+
+	cfg, err = s.parser.Parse(t, []string{t.Name()})
+	require.NoError(t, err)
+	require.Equal(t, 500, cfg.MaxStack)
+}
+
+// TestMaxTrace tests that the MaxTrace field is set by the --max-trace flag,
+// and that the default is set when the flag is not present.
+func (s *Suite) TestMaxTrace() {
+	t := s.T()
+
+	cfg, err := s.parser.Parse(t, []string{t.Name(), "--max-trace", "10"})
+	require.NoError(t, err)
+	require.Equal(t, 10, cfg.MaxTrace)
+
+	cfg, err = s.parser.Parse(t, []string{t.Name()})
+	require.NoError(t, err)
+	require.Equal(t, 20, cfg.MaxTrace)
+}

--- a/flag.go
+++ b/flag.go
@@ -42,6 +42,8 @@ func ConfigFlagsVar(fs *flag.FlagSet, c *Config) {
 	TLACodeVar(fs, c.TLAVars, "tla-code", "Add top-level arg `var[=code]` (from environment if <code> is omitted)")
 	TLAStrFileVar(fs, c.TLAVars, "tla-str-file", "Add top-level arg `var=file` string from a file")
 	TLACodeFileVar(fs, c.TLAVars, "tla-code-file", "Add top-level arg `var=file` code from a file")
+	fs.IntVar(&c.MaxStack, "max-stack", 500, "Number of allowed stack frames of jsonnet VM")
+	fs.IntVar(&c.MaxTrace, "max-trace", 20, "Maximum number of stack frames output on error")
 
 	// Add short flags. TODO(camh): consider making these optional.
 	StringSliceVar(fs, &c.ImportPath, "J", "Add a library search `dir`")


### PR DESCRIPTION
Add the --max-stack and --max-trace flags to set the maximum jsonnet VM
stack size (in frames) and the maximum number of frames printed in error
output. The defaults of 500 and 20 respectively come from the jsonnet
source. It would be nice to not set these values on the VM if the flags
are not present, but it's also nice to know from the cli help what the
defaults are. I went with the latter.

The flags do not use the `-s`/`-t` short flags used by the jsonnet
binary. These options are rather esoteric and I don't feel they deserve
a short flag.